### PR TITLE
Engines must manually require other engines they depend upon

### DIFF
--- a/lib/testeng/engine.rb
+++ b/lib/testeng/engine.rb
@@ -1,3 +1,5 @@
+require "font-awesome-rails"
+
 module Testeng
   class Engine < ::Rails::Engine
     isolate_namespace Testeng


### PR DESCRIPTION
Good article about the reasons for this here:
https://bibwild.wordpress.com/2013/02/27/gem-depends-on-rails-engine-gem-gotcha-need-explicit-require/

Here's a StackOverflow answer that helps confirm this:
http://stackoverflow.com/a/5850503/8985
